### PR TITLE
Adding ability to map match fields into opsgenie details

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1648,6 +1648,15 @@ Optional:
 
 ``opsgenie_priority``: Set the OpsGenie priority level. Possible values are P1, P2, P3, P4, P5.
 
+``opsgenie_details``: Map of custom key/value pairs to include in the alert's details. The value can sourced from either fields in the first match, environment variables, or a constant value.
+
+Example usage::
+
+    opsgenie_details:
+      Author: 'Bob Smith'          # constant value
+      Environment: '$VAR'          # environment variable
+      Message: { field: message }  # field in the first match
+
 SNS
 ~~~
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -288,6 +288,20 @@ properties:
   mattermost_msg_pretext: {type: string}
   mattermost_msg_fields: *mattermostField
 
+  ## Opsgenie
+  opsgenie_details:
+    type: object
+    minProperties: 1
+    patternProperties:
+      "^.+$":
+        oneOf:
+          - type: string
+          - type: object
+            additionalProperties: false
+            required: [field]
+            properties:
+              field: {type: string, minLength: 1}
+
   ### PagerDuty
   pagerduty_service_key: {type: string}
   pagerduty_client_name: {type: string}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -614,7 +614,7 @@ def test_opsgenie_details_with_non_string_field():
         'description': BasicMatchString(rule, match).__str__(),
         'details': {
             'Age': '10',
-            'Message': "{'format': 'The cow goes %s!', 'arg0': 'moo'}"
+            'Message': "{'arg0': 'moo', 'format': 'The cow goes %s!'}"
         },
         'message': 'ElastAlert: Opsgenie Details',
         'priority': None,

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -589,11 +589,7 @@ def test_opsgenie_details_with_non_string_field():
         }
     }
     match = {
-        'age': 10,
-        'message': {
-            'format': 'The cow goes %s!',
-            'arg0': 'moo'
-        }
+        'age': 10
     }
     alert = OpsGenieAlerter(rule)
 
@@ -612,10 +608,7 @@ def test_opsgenie_details_with_non_string_field():
 
     expected_json = {
         'description': BasicMatchString(rule, match).__str__(),
-        'details': {
-            'Age': '10',
-            'Message': "{'arg0': 'moo', 'format': 'The cow goes %s!'}"
-        },
+        'details': {'Age': '10'},
         'message': 'ElastAlert: Opsgenie Details',
         'priority': None,
         'source': 'ElastAlert',


### PR DESCRIPTION
Adding support for Opsgenie alert details, that show up as extra properties.  Details are a key/value pair map.

https://docs.opsgenie.com/docs/alert-api#section-create-alert

Example config:

```
opsgenie_details:
  Kibana Url: { field: kibana_discover_url }
  Message: { field: message }
  Testing: 'yes'
```

![image](https://user-images.githubusercontent.com/12101120/65717766-1385b700-e070-11e9-93ac-1c83a2ab6341.png)
